### PR TITLE
#129 #116 Move to last item if model shrinks

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -531,6 +531,10 @@
                             $scope.startIndex = $$options.latch ? _minStartIndex : __startIndex;
                             $scope.endIndex = $$options.latch ? _maxEndIndex : __endIndex;
 
+                            // Move to the end of the collection if we are now past it
+                            if (_maxEndIndex < $scope.startIndex)
+                                $scope.startIndex = _maxEndIndex;
+
                             var digestRequired = false;
                             if (_prevStartIndex == null) {
                                 digestRequired = true;


### PR DESCRIPTION
If the collection shrinks while we are scrolled below its new rendered size,
the scroll position currently doesn't change. This commit moves us to the
end of the collection if this scenario occurs.